### PR TITLE
fix: Force pushing changes to origin remote

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -134,6 +134,7 @@ jobs:
           release: ${{ matrix.release }}
           packagecloud_token: ${{ secrets.LINZCI_PACKAGECLOUD_TOKEN }}
           packagecloud_repository: ${{ env.PACKAGECLOUD_REPOSITORY }}
+          push_to_git_remote: origin
 
   finalise:
     if: always()


### PR DESCRIPTION
linz-software-repository seems to do the wrong thing <https://github.com/linz/linz-software-repository/issues/113> when building for more than one release.